### PR TITLE
Reading of PNGs seems to work now.

### DIFF
--- a/Graphics/Color.cs
+++ b/Graphics/Color.cs
@@ -134,9 +134,9 @@ public class Color
     /// <param name="gammaCorrect">Whether to apply gamma correction.</param>
     /// <returns>The prepared channel value.</returns>
     private static double PrepareChannelValue(
-        double value, double power = 0, bool gammaCorrect = false)
+        double value, double power = 1, bool gammaCorrect = false)
     {
-        if (gammaCorrect)
+        if (gammaCorrect && Math.Abs(power - 1) > 0.0000001)
             value = Math.Pow(value, power);
 
         return Math.Clamp(value, 0, 1);
@@ -163,6 +163,16 @@ public class Color
     public Color WithAlpha(double alpha)
     {
         return new Color(Red, Green, Blue, alpha);
+    }
+
+    /// <summary>
+    /// This method produces a string representation for the color  It is intended for use
+    /// in debugging so is very simplistic.
+    /// </summary>
+    /// <returns>A descriptive string that represents this color.</returns>
+    public override string ToString()
+    {
+        return $"Color({Red}, {Green}, {Blue}, {Alpha})";
     }
 
     // -------------------------------------------------------------------------

--- a/ImageIO/ImageFileIO.cs
+++ b/ImageIO/ImageFileIO.cs
@@ -272,12 +272,24 @@ public static class ImageFileIo
     /// and the end of the stream has been reached.</returns>
     public static int ReadBytes(Stream stream, byte[] bytes, bool isRequired = true)
     {
-        int read = stream.Read(bytes, 0, bytes.Length);
+        int offset = 0;
+        int bytesToRead = bytes.Length;
 
-        if ((read == 0 && isRequired) || (read > 0 && read < bytes.Length))
+        while (bytesToRead > 0)
+        {
+            int read = stream.Read(bytes, offset, bytesToRead);
+
+            bytesToRead -= read;
+            offset += read;
+
+            if (read == 0)
+                break;
+        }
+
+        if (bytesToRead > 0 && isRequired)
             throw new Exception("PNG Image file is corrupted.  End of file unexpectedly reached.");
 
-        return read;
+        return bytesToRead > 0 ? 0 : bytes.Length;
     }
 
     /// <summary>

--- a/ImageIO/Png/PngFilterType.cs
+++ b/ImageIO/Png/PngFilterType.cs
@@ -122,7 +122,7 @@ internal static class PngFilterTypeExtensions
             _ => throw new Exception("Internal error: unknown filter type.")
         };
 
-        filtered[x] = (byte) (value & 0x000000FF);
+        current[x] = (byte) (value & 0x000000FF);
     }
 
     /// <summary>

--- a/ImageIO/Png/PngImageStream.cs
+++ b/ImageIO/Png/PngImageStream.cs
@@ -51,7 +51,6 @@ public class PngImageStream : Stream
     /// <returns>The number of bytes we actually transferred.</returns>
     public override int Read(byte[] buffer, int offset, int maxCount)
     {
-        // If we're already done, tell 'em
         int totalBytesRead = 0;
 
         while (maxCount > 0 && _imageDataChunk != null)
@@ -61,6 +60,7 @@ public class PngImageStream : Stream
             Buffer.BlockCopy(_imageDataChunk.ImageData, _cp, buffer, offset, count);
 
             _cp += count;
+            offset += count;
             totalBytesRead += count;
             maxCount -= count;
 

--- a/ProgramOptions.cs
+++ b/ProgramOptions.cs
@@ -103,8 +103,8 @@ public class ProgramOptions
         get => _gamma;
         set
         {
-            if (value is < 8 or > 5)
-                throw new ArgumentException($"Gamma correction must be between 0 ang 5.");
+            if (value is < 0 or > 5)
+                throw new ArgumentException($"Gamma correction must be between 0 and 5.");
 
             _gamma = value;
         }

--- a/Tests/TestPngCodec.cs
+++ b/Tests/TestPngCodec.cs
@@ -1,0 +1,67 @@
+using RayTracer;
+using RayTracer.Graphics;
+using RayTracer.ImageIO;
+
+namespace Tests;
+
+[TestClass]
+public class TestPngCodec
+{
+    private static readonly Color[] ColorSet =
+    [
+        Colors.Aqua, Colors.Black, Colors.Gold, Colors.Green, Colors.Indigo
+    ];
+
+    [TestMethod]
+    public void TestRoundTrip()
+    {
+        // For testing, it's important to make sure we don't do gamma correction since
+        // that will throw off roundtrip color matching.
+        _ = new ProgramOptions { Gamma = 1 };
+
+        PngCodec codec = new PngCodec();
+        Canvas source = CreateCanvas();
+
+        using MemoryStream stream = new MemoryStream();
+
+        codec.Encode(source, stream, null);
+
+        stream.Seek(0, SeekOrigin.Begin);
+
+        Canvas[] targets = codec.Decode(stream);
+        
+        Assert.AreEqual(1, targets.Length);
+        Assert.AreEqual(6, targets[0].Width);
+        Assert.AreEqual(5, targets[0].Height);
+
+        for (int y = 0; y < targets[0].Height; y++)
+            AssertLineIsColor(targets[0], y);
+    }
+
+    private static Canvas CreateCanvas()
+    {
+        Canvas canvas = new Canvas(6, 5);
+
+        for (int y = 0; y < canvas.Height; y++)
+        {
+            for (int x = 0; x < canvas.Width; x++)
+            {
+                canvas.SetColor(ColorSet[y], x, y);
+            }
+        }
+
+        return canvas;
+    }
+
+    private static void AssertLineIsColor(Canvas canvas, int y)
+    {
+        Color expected = ColorSet[y];
+
+        for (int x = 0; x < canvas.Width; x++)
+        {
+            Color color = canvas.GetPixel(x, y);
+            
+            Assert.IsTrue(expected.Matches(color), $"Expected {expected} != actual {color}.");
+        }
+    }
+}


### PR DESCRIPTION
The reading side of the PNG codec now seems to work.  Plus these:

* Several bug fixes, including a sneaky one with filtering on the read side.
* There's a new unit test that creates a (very small) canvas, writes it with the PNG codec to a memory stream, then reads that stream back to verify that the PNG codec will round-trip an image.