### PR TITLE
Refactored output level handling and cleaned up some PNG things.

### DIFF
--- a/General/OutputLevel.cs
+++ b/General/OutputLevel.cs
@@ -1,0 +1,12 @@
+namespace RayTracer.General;
+
+/// <summary>
+/// This enumeration notes the various levels of output we support.
+/// </summary>
+public enum OutputLevel
+{
+    Quiet = 0,
+    Normal = 1,
+    Chatty = 2,
+    Verbose = 3
+}

--- a/ImageIO/Png/PngChunk.cs
+++ b/ImageIO/Png/PngChunk.cs
@@ -1,3 +1,5 @@
+using RayTracer.General;
+
 namespace RayTracer.ImageIO.Png;
 
 /// <summary>
@@ -41,6 +43,8 @@ public abstract class PngChunk
         ImageFileIo.WriteText(stream, Type);
         ImageFileIo.WriteBytes(stream, data);
         ImageFileIo.WriteUInt(stream, calculatedCrc, 4);
+
+        Dump(data.Length);
     }
 
     /// <summary>
@@ -75,6 +79,7 @@ public abstract class PngChunk
         using MemoryStream stream = new MemoryStream(data);
 
         ReadData(reader, data, stream);
+        Dump(data.Length);
     }
 
     /// <summary>
@@ -85,4 +90,35 @@ public abstract class PngChunk
     /// <param name="data">The raw data to initialize from.</param>
     /// <param name="stream">The raw data as a stream.</param>
     protected abstract void ReadData(PngChunkReader reader, byte[] data, Stream stream);
+
+    /// <summary>
+    /// This method is used to print out details about this chunk.  Output level must be
+    /// higher than normal to see anything.
+    /// </summary>
+    /// <param name="length">The length of the raw data.</param>
+    private void Dump(int length)
+    {
+        if (ProgramOptions.Instance.OutputLevel < OutputLevel.Chatty)
+            return;
+
+        string name = GetType().Name;
+
+        if (name.StartsWith("Png"))
+            name = name[3..];
+
+        Terminal.Out($"--> {Type}: {name} ({length})", OutputLevel.Chatty);
+
+        if (ProgramOptions.Instance.OutputLevel > OutputLevel.Chatty)
+            DumpDetails();
+    }
+
+    /// <summary>
+    /// This may be overridden by subclasses that know out to write out details about
+    /// themselves.  <see cref="Terminal"/>'s <c>Out()</c> method must be called with the
+    /// <c>Verbose</c> level.
+    /// </summary>
+    protected virtual void DumpDetails()
+    {
+        // No-op.
+    }
 }

--- a/ImageIO/Png/PngChunkReader.cs
+++ b/ImageIO/Png/PngChunkReader.cs
@@ -184,20 +184,13 @@ public class PngChunkReader
     /// </summary>
     private void VerifyFileTrailer()
     {
-        PngChunk chunk;
-
         while (EndChunk == null)
         {
-            chunk = GetNextChunk();
-            
+            PngChunk chunk = GetNextChunk();
+
             if (chunk.IsCritical && EndChunk == null)
                 throw new Exception($"PNG image file format is incorrect.  Found ${chunk.Type} after image data.");
         }
-
-        chunk = GetNextChunk();
-
-        if (chunk != null)
-            throw new Exception($"PNG image file format is incorrect.  Found ${chunk.Type} after end chunk.");
     }
 
     /// <summary>
@@ -327,41 +320,6 @@ public class PngChunkReader
 
         chunk.SetData(this, data);
 
-        // Only dump if the user wants to see it all.
-        if (ProgramOptions.Instance.Verbose)
-            Dump(chunk, data.Length);
-
         return chunk;
-    }
-
-    /// <summary>
-    /// This is a helper method for debugging.  It dumps what chunks a reader has read.
-    /// </summary>
-    /// <param name="chunk">The chunk to dump.</param>
-    /// <param name="length">The length of the chunck.</param>
-    private static void Dump(PngChunk chunk, int length)
-    {
-        string name = chunk.GetType().Name;
-
-        if (name.StartsWith("Png"))
-            name = name[3..];
-
-        Terminal.Out($"--> {chunk.Type}: {name} ({length})", true);
-
-        switch (chunk)
-        {
-            case PngHeaderChunk headerChunk:
-                Terminal.Out($"---->  Dimension: ({headerChunk.ImageWidth}, {headerChunk.ImageHeight})", true);
-                Terminal.Out($"---->  Bit depth: {headerChunk.BitDepth}", true);
-                Terminal.Out($"----> Color type: {headerChunk.ColorType}", true);
-                break;
-            case PngI18NTextChunk i18NTextChunk:
-                Terminal.Out($"----> Keyword: {i18NTextChunk.Keyword}", true);
-                Terminal.Out($"----> Language tag: {i18NTextChunk.LanguageTag}", true);
-                Terminal.Out($"----> Translated keyword: {i18NTextChunk.TranslatedKeyword}", true);
-                Terminal.Out($"----> Text:", true);
-                Terminal.Out($"---->     {i18NTextChunk.Text}", true);
-                break;
-        }
     }
 }

--- a/ImageIO/Png/PngHeaderChunk.cs
+++ b/ImageIO/Png/PngHeaderChunk.cs
@@ -1,3 +1,5 @@
+using RayTracer.General;
+
 namespace RayTracer.ImageIO.Png;
 
 /// <summary>
@@ -142,5 +144,15 @@ public class PngHeaderChunk : PngChunk
         CompressionMethod = ImageFileIo.ReadByte(stream) ?? 0;
         FilterMethod = ImageFileIo.ReadByte(stream) ?? 0;
         Interlaced = ImageFileIo.ReadByte(stream) > 0;
+    }
+
+    /// <summary>
+    /// This method dumps the contents of this chunk to the terminal.
+    /// </summary>
+    protected override void DumpDetails()
+    {
+        Terminal.Out($"---->  Dimension: ({ImageWidth}, {ImageHeight})", OutputLevel.Verbose);
+        Terminal.Out($"---->  Bit depth: {BitDepth}", OutputLevel.Verbose);
+        Terminal.Out($"----> Color type: {ColorType}", OutputLevel.Verbose);
     }
 }

--- a/ImageIO/Png/PngI18NTextChunk.cs
+++ b/ImageIO/Png/PngI18NTextChunk.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Text;
+using RayTracer.General;
 
 namespace RayTracer.ImageIO.Png;
 
@@ -72,5 +73,17 @@ public class PngI18NTextChunk : PngChunk
 
             Text = Encoding.UTF8.GetString(buffer.ToArray());
         }
+    }
+
+    /// <summary>
+    /// This method dumps the contents of this chunk to the terminal.
+    /// </summary>
+    protected override void DumpDetails()
+    {
+        Terminal.Out($"----> Keyword: {Keyword}", OutputLevel.Verbose);
+        Terminal.Out($"----> Language tag: {LanguageTag}", OutputLevel.Verbose);
+        Terminal.Out($"----> Translated keyword: {TranslatedKeyword}", OutputLevel.Verbose);
+        Terminal.Out($"----> Text:", OutputLevel.Verbose);
+        Terminal.Out($"---->     {Text}", OutputLevel.Verbose);
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using CommandLine;
+using CommandLine.Text;
 using RayTracer;
+using RayTracer.General;
 using RayTracer.Graphics;
 using RayTracer.Parser;
 
@@ -11,11 +13,11 @@ Parser.Default.ParseArguments<ProgramOptions>(args)
             .Parse();
         Canvas canvas = renderData.NewCanvas;
 
-        Terminal.Out("Ray Tracer v1.0.0");
-        Terminal.Out("Input file:", true);
-        Terminal.Out($"--> {options.InputFileName}", true);
-        Terminal.Out("Output file:", true);
-        Terminal.Out($"--> {options.OutputFileName}", true);
+        Terminal.Out(HeadingInfo.Default);
+        Terminal.Out("Input file:", OutputLevel.Chatty);
+        Terminal.Out($"--> {options.InputFileName}", OutputLevel.Chatty);
+        Terminal.Out("Output file:", OutputLevel.Chatty);
+        Terminal.Out($"--> {options.OutputFileName}", OutputLevel.Chatty);
 
         Terminal.Out("Generating...");
 

--- a/ProgramOptions.cs
+++ b/ProgramOptions.cs
@@ -1,5 +1,12 @@
+using System.Reflection;
 using CommandLine;
+using RayTracer.General;
 using RayTracer.ImageIO;
+
+[assembly: AssemblyTitle("My Ray Tracer")]
+[assembly: AssemblyDescription("A ray tracer based on the book, 'The Ray Tracer Challenge'")]
+[assembly: AssemblyCopyright("Copyright \u00a9 2024")]
+[assembly: AssemblyInformationalVersion("1.0.1")]
 
 namespace RayTracer;
 
@@ -114,13 +121,10 @@ public class ProgramOptions
         HelpText = "Grayscale the image when written to image file.")]
     public bool Grayscale { get; set; }
 
-    [Option('q', "quiet", Required = false,
-        HelpText = "Set this to true to get no output.")]
-    public bool Quiet { get; set; }
-
-    [Option('v', "verbose", Required = false,
-        HelpText = "Set this to true to get more output.")]
-    public bool Verbose { get; set; }
+    [Option('l', "output-level", Required = false,
+        Default = OutputLevel.Normal,
+        HelpText = "Sets the desired level of output.  Must be one of, Quiet, Normal, Chatty or Verbose.")]
+    public OutputLevel OutputLevel { get; set; }
 
     /// <summary>
     /// This property provides the largest value a color channel can have.

--- a/RayTracer.csproj
+++ b/RayTracer.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <LangVersion>12</LangVersion>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Terminal.cs
+++ b/Terminal.cs
@@ -1,3 +1,5 @@
+using RayTracer.General;
+
 namespace RayTracer;
 
 /// <summary>
@@ -10,12 +12,11 @@ public static class Terminal
     /// verbose switches in the program's options.
     /// </summary>
     /// <param name="text">The text to write out.</param>
-    /// <param name="isVerbose">Whether the text is considered verbose output.</param>
+    /// <param name="outputLevel">The level of output at which the text should be written.</param>
     /// <param name="newLine">Whether a newline should be emitted as well.</param>
-    public static void Out(string text, bool isVerbose = false, bool newLine = true)
+    public static void Out(string text, OutputLevel outputLevel = OutputLevel.Normal, bool newLine = true)
     {
-        if (!ProgramOptions.Instance.Quiet &&
-            (ProgramOptions.Instance.Verbose || !isVerbose))
+        if (ProgramOptions.Instance.OutputLevel >= outputLevel)
         {
             Console.Write(text);
 


### PR DESCRIPTION
Tossed the `-q` and `-v` cmd line arguments in favor of an `-l`/`--output-level` one using an enum (couldn't get `FlagCounter` to work to support multiple `-v`s).

Also cleaned up a bit of the PNG image I/O.  Had to go with a "compress to in-memory buffer" approach to get everything to work right when writing and just tossed the idea of checking for data after `IEND` when reading.  Things are much better now.