### PR TITLE
Check off the three to-dos that have shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ I want to add.  Once an item is checked, you can assume it's done.
 - [ ] Motion blur.
 
 ### To-Dos for Lights:
-- [ ] Area lights/soft shadows.
-- [ ] Spotlights.
+- [x] Area lights/soft shadows.
+- [x] Spotlights.
 
 ### To-Dos for Cameras:
 - [ ] Focal blur.
 
 ### To-Dos for Surfaces:
-- [ ] Normal perturbation.
+- [x] Normal perturbation.
 - [ ] Other surfaces
 
 More to come...


### PR DESCRIPTION
The README says outright that a checked item can be assumed done, but three items were shipped without the box being ticked, so the list has been understating the engine:

- **Normal perturbation** — #53
- **Spotlights** — #54
- **Area lights/soft shadows** — #55

Nothing but the README changes here; three characters, no code.

One thing left alone deliberately: #54 also shipped **distant lights**, which the list has never had an entry for at all. Adding a line rather than ticking one seemed like your call to make, so I left it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)