### PR TITLE
Take the brackets off a matrix, and let one serve as a motion

### DIFF
--- a/Instructions/Transforms/MatrixCreator.cs
+++ b/Instructions/Transforms/MatrixCreator.cs
@@ -9,16 +9,22 @@ namespace RayTracer.Instructions.Transforms;
 public class MatrixCreator : TransformCreator
 {
     /// <summary>
+    /// A matrix does nothing at all when it is the identity: ones down the diagonal, zeros
+    /// everywhere else.  Measuring every one of the sixteen from zero instead would leave a matrix
+    /// given no part of the way as sixteen zeros, which is not a transform that does nothing but
+    /// one that cannot be undone at all -- and since a moving surface's matrices are inverted to
+    /// carry rays into its space, that is a scene that will not render rather than one that looks
+    /// wrong.  The numbers of a four by four laid out a row at a time put the diagonal at every
+    /// fifth of them.
+    /// </summary>
+    /// <param name="index">Which of the sixteen numbers is being measured.</param>
+    /// <returns>One on the diagonal, zero off it.</returns>
+    protected override double IdentityValueAt(int index) => index % 5 == 0 ? 1 : 0;
+
+    /// <summary>
     /// This method is used to create the appropriate shear matrix, based on the given
     /// values.
     /// </summary>
-    /// <summary>
-    /// A matrix's sixteen numbers do not come apart into a thing that can be done by degrees --
-    /// scaling them toward zero does not give a transform half way to it, it gives nonsense -- so
-    /// a bare matrix cannot serve as a motion.
-    /// </summary>
-    protected override bool CanBeGivenInPart => false;
-
     /// <param name="context">The current render context.</param>
     /// <param name="doubles">The array of doubles, if any, our terms resolved to.</param>
     /// <param name="tuples">The array of tuples, if any, our terms resolved to.</param>

--- a/Instructions/Transforms/ScaleCreator.cs
+++ b/Instructions/Transforms/ScaleCreator.cs
@@ -9,16 +9,16 @@ namespace RayTracer.Instructions.Transforms;
 public class ScaleCreator : TransformCreator
 {
     /// <summary>
-    /// This method is used to create the appropriate scale matrix, based on the given
-    /// values.
-    /// </summary>
-    /// <summary>
     /// Scaling by nothing means scaling by one, so a scale given part way is measured from there
     /// rather than from zero, which would shrink the thing away to nothing at the outset.
     /// </summary>
     protected override double IdentityValue => 1;
 
-    /// <param name="context"></param>
+    /// <summary>
+    /// This method is used to create the appropriate scale matrix, based on the given
+    /// values.
+    /// </summary>
+    /// <param name="context">The current render context.</param>
     /// <param name="doubles">The array of doubles, if any, our terms resolved to.</param>
     /// <param name="tuples">The array of tuples, if any, our terms resolved to.</param>
     /// <returns>The created matrix.</returns>

--- a/Instructions/Transforms/TransformCreator.cs
+++ b/Instructions/Transforms/TransformCreator.cs
@@ -50,10 +50,14 @@ public abstract class TransformCreator : Resolver<Matrix>
     protected virtual double IdentityValue => 0;
 
     /// <summary>
-    /// This property notes whether this transform can be given part way.  All of them can but a
-    /// bare matrix, whose numbers mean nothing on their own.
+    /// This method holds the same thing for transforms whose idea of doing nothing is not one
+    /// number repeated.  A matrix is the only such: its numbers are a grid rather than a list, and
+    /// doing nothing means ones down the diagonal and zeros everywhere else, so which number is
+    /// being measured decides what it is measured from.
     /// </summary>
-    protected virtual bool CanBeGivenInPart => true;
+    /// <param name="index">Which of this transform's numbers is being measured.</param>
+    /// <returns>The value that number takes when the transform does nothing at all.</returns>
+    protected virtual double IdentityValueAt(int index) => IdentityValue;
 
     /// <summary>
     /// This method is used to execute the resolver to produce a value.
@@ -98,22 +102,20 @@ public abstract class TransformCreator : Resolver<Matrix>
         // it always did.
         if (fraction != 1)
         {
-            if (!CanBeGivenInPart)
-            {
-                throw new Exception(
-                    "A matrix cannot be given part way, so it cannot be used as a motion.");
-            }
-
-            doubles = doubles.Select(PartWay).ToArray();
+            doubles = doubles.Select(PartWayAt).ToArray();
             tuples = tuples
                 .Select(tuple => new NumberTuple(
-                    PartWay(tuple.X), PartWay(tuple.Y), PartWay(tuple.Z), tuple.W))
+                    PartWay(tuple.X, IdentityValue), PartWay(tuple.Y, IdentityValue),
+                    PartWay(tuple.Z, IdentityValue), tuple.W))
                 .ToArray();
         }
 
         return CreateTransform(context, doubles, tuples);
 
-        double PartWay(double value) => IdentityValue + (value - IdentityValue) * fraction;
+        double PartWayAt(double value, int index) => PartWay(value, IdentityValueAt(index));
+
+        double PartWay(double value, double identity) =>
+            identity + (value - identity) * fraction;
     }
 
     /// <summary>

--- a/Parser/LanguageParser.Transforms.cs
+++ b/Parser/LanguageParser.Transforms.cs
@@ -79,13 +79,11 @@ public partial class LanguageParser
                     break;
                 case TransformType.Shear:
                     creator = new ShearCreator();
-                    transformTerms = terms[..6].ToArray();
-                    terms.RemoveRange(0, 6);
+                    transformTerms = TakeBracketedTerms(clause, terms, 6);
                     break;
                 case TransformType.Matrix:
                     creator = new MatrixCreator();
-                    transformTerms = terms[..16].ToArray();
-                    terms.RemoveRange(0, 16);
+                    transformTerms = TakeBracketedTerms(clause, terms, 16);
                     break;
                 default:
                     throw new Exception("Unknown transform type");
@@ -98,6 +96,29 @@ public partial class LanguageParser
         }
 
         return resolver;
+    }
+
+    /// <summary>
+    /// This is a helper method for pulling the terms of a bracketed, comma-separated list
+    /// of values, such as the one a shear or matrix carries, out of the given list of
+    /// terms.  The grammar leaves the brackets and separating commas in the clause's list
+    /// of tokens, so we discard those here as well; if we didn't, the next trip around the
+    /// parsing loop would try to read one of them as the name of a transform.
+    /// </summary>
+    /// <param name="clause">The clause to remove the punctuation tokens from.</param>
+    /// <param name="terms">The list of terms to pull from.</param>
+    /// <param name="count">The number of values in the list.</param>
+    /// <returns>The terms for the values in the list.</returns>
+    private static Term[] TakeBracketedTerms(Clause clause, List<Term> terms, int count)
+    {
+        Term[] result = terms[..count].ToArray();
+
+        terms.RemoveRange(0, count);
+
+        // The open bracket, the commas that separate the values, and the close bracket.
+        clause.Tokens.RemoveRange(0, count + 1);
+
+        return result;
     }
 
     /// <summary>

--- a/Tests/TestTransformClauses.cs
+++ b/Tests/TestTransformClauses.cs
@@ -1,0 +1,358 @@
+using RayTracer.Graphics;
+using RayTracer.ImageIO;
+using RayTracer.Options;
+using RayTracer.Parser;
+using RayTracer.Renderer;
+
+namespace Tests;
+
+/// <summary>
+/// These tests cover how a scene writes each sort of transform, checked by rendering, since a
+/// transform clause that parses may still put a surface in the wrong place -- or, as "matrix" and
+/// "shear" once did, leave punctuation behind that the next transform in the list trips over.
+/// What each matrix does to a point is settled at the math level in <see cref="TestTransforms"/>,
+/// and what a motion does with one over an open shutter in <see cref="TestMotionBlur"/>; here a
+/// motion is only asked which transforms it will take at all.
+/// </summary>
+[TestClass]
+public class TestTransformClauses
+{
+    private string _directory;
+
+    [TestInitialize]
+    public void CreateWorkingDirectory()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), $"transform-tests-{Guid.NewGuid():N}");
+
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TestCleanup]
+    public void RemoveWorkingDirectory()
+    {
+        if (Directory.Exists(_directory))
+            Directory.Delete(_directory, true);
+    }
+
+    /// <summary>
+    /// A camera that sees the ball straight on and holds still, which is all these tests need of
+    /// one.  <see cref="OpenShutter"/> is the same camera with its shutter left open, for when a
+    /// motion has to actually be looked at.
+    /// </summary>
+    private const string StillCamera = "camera { location [0, 0, -8] look at [0, 0, 0] }";
+
+    /// <summary>
+    /// The same camera with its shutter open, so that the instants either side of the shutter's
+    /// middle are looked at -- which is the only thing that asks a motion's transforms for a
+    /// part-way version of themselves.
+    /// </summary>
+    private const string OpenShutter =
+        "camera { location [0, 0, -8] look at [0, 0, 0] shutter 1 blur samples 8 }";
+
+    /// <summary>
+    /// Renders a ball under the given transform clauses, flat white on black so that where it
+    /// lands can be read straight off the image, and returns the render, or reports the error
+    /// that stopped it.
+    /// </summary>
+    private Canvas Render(
+        string transforms, out string error, string camera = StillCamera, int size = 80)
+    {
+        string path = Path.Combine(_directory, $"scene-{Guid.NewGuid():N}.igl");
+        string output = Path.ChangeExtension(path, "png");
+
+        File.WriteAllText(path,
+            camera + "\n" +
+            "light { location [0, 0, -8] }\n" +
+            "sphere {\n" +
+            "    material { pigment color [1, 1, 1] ambient 1 diffuse 0 specular 0 }\n" +
+            transforms + "\n" +
+            "}");
+
+        StringWriter captured = new ();
+        TextWriter was = Console.Out;
+
+        Console.SetOut(captured);
+
+        try
+        {
+            ImageRenderer renderer = new LanguageParser(path).Parse();
+
+            if (renderer is null)
+            {
+                error = captured.ToString();
+
+                return null;
+            }
+
+            try
+            {
+                renderer.Render(new RenderOptions
+                {
+                    OutputFileName = output, Width = size, Height = size
+                });
+            }
+            catch (Exception exception)
+            {
+                // A scene may also be refused once it is being rendered rather than while it is
+                // being read -- a matrix used as a motion is -- and out here that arrives as an
+                // exception, since it is the command line that turns one into a printed complaint.
+                error = exception.Message;
+
+                return null;
+            }
+
+            error = captured.ToString().Contains("Error") ? captured.ToString() : null;
+
+            return error is null ? new ImageFile(output).Load()[0] : null;
+        }
+        finally
+        {
+            Console.SetOut(was);
+        }
+    }
+
+    /// <summary>
+    /// Returns the centre of the lit pixels in the given image, in pixels across and down.  This
+    /// is where the ball ended up, which is what a transform clause is judged on.
+    /// </summary>
+    private static (double X, double Y) CentreOfLight(Canvas image)
+    {
+        double totalX = 0, totalY = 0, weight = 0;
+
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                Color pixel = image.GetPixel(x, y);
+                double brightness = (pixel.Red + pixel.Green + pixel.Blue) / 3;
+
+                totalX += x * brightness;
+                totalY += y * brightness;
+                weight += brightness;
+            }
+        }
+
+        Assert.IsTrue(weight > 0, "the ball should be somewhere in the image");
+
+        return (totalX / weight, totalY / weight);
+    }
+
+    /// <summary>
+    /// Returns the number of pixels at which the two images differ.
+    /// </summary>
+    private static int PixelsThatDiffer(Canvas first, Canvas second)
+    {
+        Assert.AreEqual(first.Width, second.Width);
+        Assert.AreEqual(first.Height, second.Height);
+
+        int count = 0;
+
+        for (int y = 0; y < first.Height; y++)
+        {
+            for (int x = 0; x < first.Width; x++)
+            {
+                if (!first.GetPixel(x, y).Matches(second.GetPixel(x, y)))
+                    count++;
+            }
+        }
+
+        return count;
+    }
+
+    [TestMethod]
+    public void TestAMatrixParses()
+    {
+        // The bug this guards: the grammar hands the clause the brackets and the fifteen commas
+        // as tokens, and nothing used to take them off the list, so the loop read "[" as the name
+        // of the next transform and gave up on the scene entirely.
+        Canvas image = Render(
+            "matrix [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]", out string error);
+
+        Assert.IsNull(error, $"a matrix should parse: {error}");
+        Assert.IsNotNull(image);
+    }
+
+    [TestMethod]
+    public void TestAMatrixPlacesASurfaceWhereTheSameTranslateWould()
+    {
+        // The values are read across the rows, so the fourth column carries the translation.
+        Canvas viaMatrix = Render(
+            "matrix [1, 0, 0, 2, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1]", out string matrixError);
+        Canvas viaTranslate = Render("translate [2, 1, 0]", out string translateError);
+        Canvas untouched = Render("translate [0, 0, 0]", out string plainError);
+
+        Assert.IsNull(matrixError, $"a matrix should parse: {matrixError}");
+        Assert.IsNull(translateError);
+        Assert.IsNull(plainError);
+
+        Assert.AreEqual(0, PixelsThatDiffer(viaMatrix, viaTranslate),
+            "a matrix holding a translation should render the same as that translate");
+
+        // ...and check the pair actually went somewhere, so that two identically broken renders
+        // could not pass the comparison above.
+        (double movedX, double movedY) = CentreOfLight(viaMatrix);
+        (double restingX, double restingY) = CentreOfLight(untouched);
+
+        Assert.IsTrue(Math.Abs(movedX - restingX) > 5,
+            $"the ball should have moved across the image, but sat at {movedX:F1} vs {restingX:F1}");
+        Assert.IsTrue(Math.Abs(movedY - restingY) > 2,
+            $"the ball should have moved down the image, but sat at {movedY:F1} vs {restingY:F1}");
+    }
+
+    [TestMethod]
+    public void TestAnIdentityMatrixMovesNothing()
+    {
+        Canvas viaMatrix = Render(
+            "matrix [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]", out string matrixError);
+        Canvas untouched = Render("translate [0, 0, 0]", out string plainError);
+
+        Assert.IsNull(matrixError, $"a matrix should parse: {matrixError}");
+        Assert.IsNull(plainError);
+        Assert.AreEqual(0, PixelsThatDiffer(viaMatrix, untouched));
+    }
+
+    [TestMethod]
+    public void TestAShearParses()
+    {
+        // Shear is written the same bracketed way as matrix, and was broken in the same way.
+        Canvas sheared = Render("shear [1, 0, 0, 0, 0, 0] scale 2", out string shearError);
+        Canvas plain = Render("scale 2", out string plainError);
+
+        Assert.IsNull(shearError, $"a shear should parse: {shearError}");
+        Assert.IsNull(plainError);
+        Assert.AreNotEqual(0, PixelsThatDiffer(sheared, plain),
+            "shearing a ball should lean it over, not leave it alone");
+    }
+
+    [TestMethod]
+    public void TestATransformListMayCarryOnPastAMatrix()
+    {
+        // The real test of the punctuation being taken off the list exactly: whatever follows the
+        // brackets has to be read as the next transform, and nothing else.
+        Canvas viaMatrix = Render("""
+            matrix [1, 0, 0, 2, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+            translate [0, 1, 0]
+            scale 0.5
+            """, out string matrixError);
+        Canvas viaTranslates = Render("""
+            translate [2, 0, 0]
+            translate [0, 1, 0]
+            scale 0.5
+            """, out string translateError);
+
+        Assert.IsNull(matrixError, $"a matrix in a longer list should parse: {matrixError}");
+        Assert.IsNull(translateError);
+        Assert.AreEqual(0, PixelsThatDiffer(viaMatrix, viaTranslates),
+            "the transforms after a matrix should apply just as they would after a translate");
+    }
+
+    [TestMethod]
+    public void TestATransformListMayCarryOnPastAShear()
+    {
+        Canvas withShear = Render("shear [0, 0, 0, 0, 0, 0] translate [2, 0, 0]",
+            out string shearError);
+        Canvas withoutShear = Render("translate [2, 0, 0]", out string plainError);
+
+        Assert.IsNull(shearError, $"a shear in a longer list should parse: {shearError}");
+        Assert.IsNull(plainError);
+        Assert.AreEqual(0, PixelsThatDiffer(withShear, withoutShear),
+            "a shear of nothing should leave the translate that follows it untouched");
+    }
+
+    [TestMethod]
+    public void TestAMatrixOfTheWrongSizeIsRejected()
+    {
+        Render("matrix [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0]", out string error);
+
+        Assert.IsNotNull(error, "a matrix of twelve values should be an error");
+    }
+
+    [TestMethod]
+    public void TestAMatrixMotionSmearsWhereTheSameTranslateMotionWould()
+    {
+        // A matrix given part way is measured from the identity matrix rather than from zero, so
+        // one holding a move slides exactly as the move itself does, instant for instant, and the
+        // two smears come out the same.
+        Canvas viaMatrix = Render("motion { matrix [1, 0, 0, 2, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1] }",
+            out string matrixError, OpenShutter);
+        Canvas viaTranslate = Render("motion { translate [2, 0, 0] }", out string translateError,
+            OpenShutter);
+        Canvas still = Render("", out string stillError, OpenShutter);
+
+        Assert.IsNull(matrixError, $"a matrix should serve as a motion: {matrixError}");
+        Assert.IsNull(translateError);
+        Assert.IsNull(stillError);
+
+        Assert.AreEqual(0, PixelsThatDiffer(viaMatrix, viaTranslate),
+            "a matrix holding a move should smear just as that move does");
+
+        // ...and that the pair actually smeared, so two identically still renders could not pass
+        // the comparison above.
+        Assert.AreNotEqual(0, PixelsThatDiffer(viaMatrix, still),
+            "a matrix motion should have moved the ball over the shutter's opening");
+    }
+
+    [TestMethod]
+    public void TestAMatrixMotionMeasuresAScaleFromOne()
+    {
+        // The diagonal is the half of it that measuring from zero got wrong: a matrix holding a
+        // scale has to grow from one, exactly as "scale" does, rather than from nothing.
+        Canvas viaMatrix = Render("motion { matrix [2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1] }",
+            out string matrixError, OpenShutter);
+        Canvas viaScale = Render("motion { scale 2 }", out string scaleError, OpenShutter);
+
+        Assert.IsNull(matrixError, $"a matrix holding a scale should serve as a motion: {matrixError}");
+        Assert.IsNull(scaleError);
+        Assert.AreEqual(0, PixelsThatDiffer(viaMatrix, viaScale),
+            "a matrix holding a scale should swell just as that scale does");
+    }
+
+    [TestMethod]
+    public void TestAMatrixMotionStartsWhereTheSurfaceStands()
+    {
+        // The instant at the start of the opening has to leave the surface exactly where it was
+        // placed.  Measured from zero this came out as sixteen zeros -- a matrix that cannot be
+        // inverted, and a moving surface's matrices are inverted to carry rays into its space, so
+        // the render would have failed outright rather than merely looked wrong.
+        Canvas moved = Render(
+            "translate [1, 0, 0]\nmotion { matrix [1, 0, 0, 2, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1] }",
+            out string error, OpenShutter);
+
+        Assert.IsNull(error, $"a matrix motion should render: {error}");
+        Assert.IsNotNull(moved);
+
+        // The ball is somewhere sensible rather than collapsed to a point or lost entirely.
+        (double x, double y) = CentreOfLight(moved);
+
+        Assert.IsTrue(x is > 0 and < 80 && y is > 0 and < 80,
+            $"the ball should still be in the picture, but its middle was at ({x:F1}, {y:F1})");
+    }
+
+    [TestMethod]
+    public void TestTheOtherTransformsMayBeUsedAsAMotion()
+    {
+        Canvas sheared = Render("motion { shear [1, 0, 0, 0, 0, 0] }", out string shearError,
+            OpenShutter);
+        Canvas moved = Render("motion { translate [1, 0, 0] }", out string moveError, OpenShutter);
+
+        Assert.IsNull(shearError, $"a shear should be allowed as a motion: {shearError}");
+        Assert.IsNull(moveError, $"a translate should be allowed as a motion: {moveError}");
+        Assert.IsNotNull(sheared);
+        Assert.IsNotNull(moved);
+    }
+
+    [TestMethod]
+    public void TestAMotionDoesNothingWhileTheShutterIsShut()
+    {
+        // With the shutter shut there is a single instant to see, so nothing ever asks the motion
+        // for a part-way transform and the surface stands exactly where it was placed.
+        Canvas moving = Render("motion { matrix [1, 0, 0, 2, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1] }",
+            out string movingError);
+        Canvas still = Render("", out string stillError);
+
+        Assert.IsNull(movingError, $"a shut shutter should never reach the motion: {movingError}");
+        Assert.IsNull(stillError);
+        Assert.AreEqual(0, PixelsThatDiffer(moving, still),
+            "with the shutter shut, a motion should make no difference at all");
+    }
+}


### PR DESCRIPTION
## The parsing bug

The `matrix` transform clause failed on **every** scene that used it:

```
Error: Internal error: unknown transfer type: [
```

A grammar rule that spells out its own punctuation is handed that punctuation as tokens, in `clause.Tokens`, alongside the keywords. `matrixClause` spells out an open bracket, fifteen commas and a close bracket, and nothing took them off the list — so once `matrix` was read, `ParseTransformClause`'s loop met the `[`, tried to read it as the name of the next transform, and gave up on the scene.

**`shear` was broken identically** and for the same reason; its rule spells out a bracket, five commas and a bracket. Neither word appears in any gallery scene, which is why both went unnoticed.

`translate`, `scale` and `rotate` never spell out their brackets — `translate [1, 0, 0]` arrives as a single tuple *expression*, so its brackets never reach `Tokens`. They were never affected, and nothing on their path changed.

`TakeBracketedTerms` now drops `count + 1` tokens per bracketed list: one open bracket, `count - 1` commas, one close bracket.

## A matrix as a motion

With parsing fixed, a `matrix` could reach a `motion { }` block, where it was refused outright — `CanBeGivenInPart => false`.

The rationale was sound but narrower than it looked. `PartWay` measures each of a transform's numbers from a **single scalar** `IdentityValue` — 0 for translate/rotate/shear, 1 for scale. A matrix's numbers are a grid, and its identity is not one number repeated: it is ones down the diagonal, zeros elsewhere. Measured from zero, a matrix no part of the way along becomes sixteen zeros — not a transform that does nothing, but one that cannot be inverted. Since `Surface.BuildMotionTransforms` does `MotionAt(fraction) * Transform` and inverts every result, that scene would not have rendered at all. The refusal was guarding a real failure.

But the fault is in the measuring, not in the matrix. `IdentityValueAt(int index)` now supplies a per-number identity, defaulting to the existing scalar so no other transform changes; `MatrixCreator` overrides it as `index % 5 == 0 ? 1 : 0`, the diagonal of a 4×4 laid out a row at a time. `CanBeGivenInPart` and its throw are gone — nothing else used them.

At fraction 0 a matrix is now exactly the identity: the correct "hasn't moved yet" anchor, and invertible.

### Known limit

The blend is linear. That is **exact** for moves, scales, shears and any composition of them — essentially everything anyone writes `matrix` for. It is **not** exact for a turn: a rotation matrix half way along turns half the angle but also shrinks by ~0.71 at 90°. Small angles look fine; large ones will pump. Anything wanting a spin has `rotate`, which measures the angle itself and is exact. Doing better would mean decomposing into translation/rotation/scale and slerping — a quaternion type this codebase does not have, for a case `rotate` already covers.

## Tests

New `Tests/TestTransformClauses.cs`, render-level in the style of `TestLightClauses` — 12 tests. **9 of them fail on the unfixed parser** (verified by reverting and clean-building); the rest are guards that hold either way.

The equivalences are asserted **pixel-for-pixel**, which is a stronger claim than "it renders":

| scene | renders identically to |
| --- | --- |
| `matrix [1,0,0,2, 0,1,0,1, 0,0,1,0, 0,0,0,1]` | `translate [2, 1, 0]` |
| `motion { matrix [1,0,0,2, 0,1,0,0, 0,0,1,0, 0,0,0,1] }` | `motion { translate [2, 0, 0] }` |
| `motion { matrix [2,0,0,0, 0,2,0,0, 0,0,2,0, 0,0,0,1] }` | `motion { scale 2 }` |

That last one is specifically the diagonal — the half that measuring from zero got wrong. Each equivalence is paired with a check that the pair actually moved, so two identically broken renders could not pass by matching each other. Two further tests confirm a transform list carries on correctly *past* a `matrix` and past a `shear`, which is what pins the token count to exactly right rather than merely large enough.

## Compatibility

The `fraction != 1` guard is untouched, so a transform applied in full still has no arithmetic laid over its numbers and every scene written before motion existed builds the matrices it always did.

`dotnet build`: 0 warnings, 0 errors. `dotnet test`: **611 passed, 0 failed**, including all of `TestMotionBlur` and `TestCameraClauses`. `gallery/challenge-book/chapter-16/csg.igl` still renders.

## Also

XML docs repaired in `MatrixCreator` and `ScaleCreator`. The motion-blur merge inserted the new member (`CanBeGivenInPart`, `IdentityValue`) into the middle of `CreateTransform`'s doc block in each, leaving the property with two `<summary>` tags and the method with `<param>`/`<returns>` and none. Comments only — nothing built or rendered differs.

The empty `<param name="context"></param>` in `TranslationCreator` was left alone: it predates all of this (`0c7db65`) and is one of eight such tags across the repo, so it is a standing style rather than damage from the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
