### PR TITLE
Scene/camera render options, and a general libraries import

### DIFF
--- a/Commands/LibrariesCommand.cs
+++ b/Commands/LibrariesCommand.cs
@@ -2,6 +2,7 @@ using RayTracer.Fonts;
 using RayTracer.Options;
 using RayTracer.Parser;
 using RayTracer.PovRay;
+using RayTracer.Renderer;
 
 namespace RayTracer.Commands;
 
@@ -33,12 +34,88 @@ public static class LibrariesCommand
     {
         if (options.ListLibraries)
             ShowExistingLibraries();
-        else if (options.ImportPovRayFrom != null)
-            ImportPovRayLibraries(options);
+        else if (options.ImportFrom != null)
+            ImportLibrary(options);
         else if (options.RemoveLibrary != null)
             RemoveLibrary(options.RemoveLibrary);
+        else if (options.Povray)
+            Terminal.ShowError("--povray only makes sense together with --import.");
         else
             Console.WriteLine("No action was specified.  Use '--help' for a list of options.");
+    }
+
+    /// <summary>
+    /// This method imports a library, either by converting a POV-Ray distribution or by copying
+    /// an .igl file of definitions, depending on whether --povray was given.
+    /// </summary>
+    /// <param name="options">The options specified by the user on the command line.</param>
+    private static void ImportLibrary(LibrariesOptions options)
+    {
+        if (options.Povray)
+            ImportPovRayLibraries(options);
+        else
+            ImportIglLibrary(options);
+    }
+
+    /// <summary>
+    /// This method imports a single .igl file as a library, after making sure it holds nothing
+    /// but definitions.
+    /// </summary>
+    /// <param name="options">The options specified by the user on the command line.</param>
+    private static void ImportIglLibrary(LibrariesOptions options)
+    {
+        string source = Path.GetFullPath(
+            Path.Combine(Directory.GetCurrentDirectory(), options.ImportFrom));
+
+        if (!File.Exists(source))
+            Terminal.ShowError($"The file, '{source}', does not exist.");
+
+        // A library is imported by name, and one is better named for what it holds than for how it
+        // is stored, so the extension is dropped from the name it lands under.
+        string name = Path.GetFileNameWithoutExtension(source);
+
+        // Read it, so a file that will not parse is turned away here rather than when a scene first
+        // tries to import from it, and so we can be sure it is only definitions.  A library that
+        // carried a surface, a camera or a render command would drag that into every scene that
+        // imported it, which is exactly what an import is meant to avoid.
+        ImageRenderer renderer = new LanguageParser(source).Parse();
+
+        if (renderer is null)
+            return;
+
+        if (!renderer.HoldsOnlyDefinitions)
+        {
+            Terminal.ShowError(
+                $"'{Path.GetFileName(source)}' cannot be a library: a library may hold only " +
+                "definitions (name = ...), but this holds other things as well.");
+        }
+
+        if (renderer.DefinitionCount == 0)
+            Terminal.ShowError($"'{Path.GetFileName(source)}' defines nothing to import.");
+
+        string target = Path.Combine(LibraryLocator.LibrariesDirectory, $"{name}.igl");
+
+        if (File.Exists(target) && !options.Replace)
+        {
+            Terminal.ShowError(
+                $"A library named '{name}' already exists.  Specify --overwrite to replace it.");
+        }
+
+        if (options.DryRun)
+        {
+            Terminal.Out(
+                $"'{name}' holds {renderer.DefinitionCount:n0} definitions and would be imported.  " +
+                "Nothing was written, since --dry-run was given.");
+
+            return;
+        }
+
+        Directory.CreateDirectory(LibraryLocator.LibrariesDirectory);
+        File.Copy(source, target, overwrite: true);
+
+        Terminal.Out(
+            $"The library '{name}', holding {renderer.DefinitionCount:n0} definitions, was " +
+            $"imported into {LibraryLocator.LibrariesDirectory}.");
     }
 
     /// <summary>
@@ -111,7 +188,7 @@ public static class LibrariesCommand
     private static void ImportPovRayLibraries(LibrariesOptions options)
     {
         string source = Path.GetFullPath(
-            Path.Combine(Directory.GetCurrentDirectory(), options.ImportPovRayFrom));
+            Path.Combine(Directory.GetCurrentDirectory(), options.ImportFrom));
 
         if (!Directory.Exists(source))
             Terminal.ShowError($"The directory, '{source}', does not exist.");

--- a/General/RenderContext.cs
+++ b/General/RenderContext.cs
@@ -98,7 +98,19 @@ public class RenderContext
     /// This property holds the statistics collector being used.
     /// </summary>
     public Statistics Statistics { get; set; }
-    
+
+    /// <summary>
+    /// This property holds the name of the scene to render, when the command line names one.  It
+    /// takes precedence over any scene the file's <c>render</c> command names.
+    /// </summary>
+    public string SceneName { get; set; }
+
+    /// <summary>
+    /// This property holds the name of the camera to render with, when the command line names one.
+    /// It takes precedence over any camera the file's <c>render</c> command names.
+    /// </summary>
+    public string CameraName { get; set; }
+
     /// <summary>
     /// This method is used to apply any options the user specified on the command line to
     /// the context.
@@ -129,5 +141,7 @@ public class RenderContext
         Grayscale = options.Grayscale;
         AntiAliasing = options.AntiAliasing;
         Ticks = seconds * 1_000 + fraction;
+        SceneName = options.SceneName;
+        CameraName = options.CameraName;
     }
 }

--- a/Instructions/InstructionContext.cs
+++ b/Instructions/InstructionContext.cs
@@ -30,6 +30,19 @@ public class InstructionContext
         .Select(instruction => instruction.VariableName)
         .ToList();
 
+    /// <summary>
+    /// This property reports whether every instruction is a plain definition -- a name bound to a
+    /// value or a thing.  A file offered as a library must be, since anything else (a surface, a
+    /// camera, a render command) would be dragged into every scene that imported it.
+    /// </summary>
+    internal bool HoldsOnlyDefinitions => _instructions
+        .All(instruction => instruction is SetVariableInstruction);
+
+    /// <summary>
+    /// This property reports how many definitions the source held.
+    /// </summary>
+    internal int DefinitionCount => _instructions.OfType<SetVariableInstruction>().Count();
+
     public void AddInstruction(Instruction instruction)
     {
         ArgumentNullException.ThrowIfNull(instruction);

--- a/Instructions/RenderInstruction.cs
+++ b/Instructions/RenderInstruction.cs
@@ -52,8 +52,8 @@ public class RenderInstruction : Instruction
     /// <param name="variables">The current set of scoped variables.</param>
     public override void Execute(RenderContext context, Variables variables)
     {
-        using Scene scene = GetScene(variables);
-        Camera camera = GetCamera(scene, variables);
+        using Scene scene = GetScene(context, variables);
+        Camera camera = GetCamera(context, scene, variables);
 
         // Give each surface a chance to do any precomputing needed, telling it the instants the
         // camera will look at so that anything set moving can work out where it stands at each of
@@ -91,9 +91,10 @@ public class RenderInstruction : Instruction
     /// <summary>
     /// This method is used to get the scene to render.
     /// </summary>
+    /// <param name="context">The current render context, which carries any command line name.</param>
     /// <param name="variables">The current set of scoped variables.</param>
     /// <returns>The scene to render.</returns>
-    private Scene GetScene(Variables variables)
+    private Scene GetScene(RenderContext context, Variables variables)
     {
         List<Scene> scenes = HasExplicitScene
             ? Objects
@@ -102,7 +103,7 @@ public class RenderInstruction : Instruction
                 .ToList()
             : [CreateImplicitScene()];
 
-        return IsolateObject(variables, scenes, _sceneName, "scene");
+        return IsolateObject(variables, scenes, context.SceneName, _sceneName, "scene");
     }
 
     /// <summary>
@@ -141,12 +142,13 @@ public class RenderInstruction : Instruction
     /// <summary>
     /// This method is used to find the proper camera to use.
     /// </summary>
+    /// <param name="context">The current render context, which carries any command line name.</param>
     /// <param name="scene">The scene to look for the camera.</param>
     /// <param name="variables">The current set of scoped variables.</param>
     /// <returns>The camera to use.</returns>
-    private Camera GetCamera(Scene scene, Variables variables)
+    private Camera GetCamera(RenderContext context, Scene scene, Variables variables)
     {
-        return IsolateObject(variables, scene.Cameras, _cameraName, "camera");
+        return IsolateObject(variables, scene.Cameras, context.CameraName, _cameraName, "camera");
     }
 
     /// <summary>
@@ -155,15 +157,17 @@ public class RenderInstruction : Instruction
     /// </summary>
     /// <param name="variables">The current set of scoped variables.</param>
     /// <param name="items">The list of items to search.</param>
+    /// <param name="overrideName">A name from the command line, which wins over the term when
+    /// given.</param>
     /// <param name="nameTerm">The term to evaluate to derive the name of the desired item
     /// if there is a name.</param>
     /// <param name="noun">A noun to use for errors.</param>
     /// <returns>The desired item.</returns>
     private static TItem IsolateObject<TItem>(
-        Variables variables, List<TItem> items, Term nameTerm, string noun)
+        Variables variables, List<TItem> items, string overrideName, Term nameTerm, string noun)
         where TItem : NamedThing
     {
-        string name = nameTerm?.GetValue<string>(variables, false);
+        string name = overrideName ?? nameTerm?.GetValue<string>(variables, false);
 
         if (name == null)
         {

--- a/Options/LibrariesOptions.cs
+++ b/Options/LibrariesOptions.cs
@@ -15,10 +15,15 @@ public class LibrariesOptions
     // ReSharper disable once UnusedAutoPropertyAccessor.Global
     public bool ListLibraries { get; set; }
 
-    [Option('p', "import-povray", Required = false, SetName = "import-povray",
-        HelpText = "Converts POV-Ray's texture include files into libraries.  The value is the directory those files live in, which is usually the 'include' directory of a POV-Ray distribution.")]
+    [Option('i', "import", Required = false, SetName = "import",
+        HelpText = "Imports a library.  Normally the value is an .igl file of definitions, which is copied into the library directory.  With --povray, it is instead the 'include' directory of a POV-Ray distribution, whose texture files are converted into libraries.")]
     // ReSharper disable once UnusedAutoPropertyAccessor.Global
-    public string ImportPovRayFrom { get; set; }
+    public string ImportFrom { get; set; }
+
+    [Option('p', "povray", Required = false,
+        HelpText = "Used with --import to say the source is a POV-Ray distribution's 'include' directory to convert, rather than a single .igl file to copy.")]
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global
+    public bool Povray { get; set; }
 
     [Option('r', "remove", Required = false, SetName = "remove",
         HelpText = "Removes a library from the ray tracer's library directory.")]

--- a/Options/RenderOptions.cs
+++ b/Options/RenderOptions.cs
@@ -77,6 +77,16 @@ public class RenderOptions
         set => _outputFileExtension = value.StartsWith('.') ? value : $".{value}";
     }
 
+    [Option("scene", Required = false,
+        HelpText = "The name of the scene to render, for a file that defines more than one.  This takes precedence over any scene named by a 'render' command in the file.")]
+    [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+    public string SceneName { get; set; }
+
+    [Option("camera", Required = false,
+        HelpText = "The name of the camera to render with, for a scene that defines more than one.  This takes precedence over any camera named by a 'render' command in the file.")]
+    [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+    public string CameraName { get; set; }
+
     // Note: no Default here, and none on Height below, deliberately.  `RenderContext.ApplyOptions`
     // merges these with `options.Width ?? Width`, so that a size the scene's own `context { }`
     // block asked for survives when the command line says nothing -- exactly as Gamma does.  A

--- a/Renderer/ImageRenderer.cs
+++ b/Renderer/ImageRenderer.cs
@@ -37,6 +37,17 @@ public class ImageRenderer
     }
 
     /// <summary>
+    /// This property reports whether the parsed source holds only definitions, as a file offered
+    /// as a library must.  See <see cref="Commands.LibrariesCommand"/>.
+    /// </summary>
+    public bool HoldsOnlyDefinitions => _instructionContext.HoldsOnlyDefinitions;
+
+    /// <summary>
+    /// This property reports how many definitions the parsed source holds.
+    /// </summary>
+    public int DefinitionCount => _instructionContext.DefinitionCount;
+
+    /// <summary>
     /// This method is used to render all images called for in our input files.
     /// </summary>
     /// <param name="options">The command line options supplied by the user.</param>

--- a/Tests/TestLibraryImport.cs
+++ b/Tests/TestLibraryImport.cs
@@ -1,0 +1,102 @@
+using RayTracer.Parser;
+using RayTracer.Renderer;
+
+namespace Tests;
+
+/// <summary>
+/// These tests cover the check that decides whether a file may be imported as a library: a
+/// library must hold only definitions, since anything else would be dragged into every scene
+/// that imported it.  The check drives <c>libraries --import</c> (without <c>--povray</c>).
+/// </summary>
+[TestClass]
+public class TestLibraryImport
+{
+    private string _directory;
+
+    [TestInitialize]
+    public void CreateWorkingDirectory()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), $"library-import-{Guid.NewGuid():N}");
+
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TestCleanup]
+    public void RemoveWorkingDirectory()
+    {
+        if (Directory.Exists(_directory))
+            Directory.Delete(_directory, true);
+    }
+
+    private ImageRenderer Parse(string text)
+    {
+        string path = Path.Combine(_directory, "library.igl");
+
+        File.WriteAllText(path, text);
+
+        return new LanguageParser(path).Parse();
+    }
+
+    [TestMethod]
+    public void TestAFileOfDefinitionsIsAcceptableAsALibrary()
+    {
+        ImageRenderer renderer = Parse(
+            "Copper = material { pigment color [0.72, 0.45, 0.2]  specular 0.8  shininess 120 }\n" +
+            "Jade = color [0.2, 0.6, 0.45]\n" +
+            "Sheen = 0.9\n");
+
+        Assert.IsTrue(renderer.HoldsOnlyDefinitions);
+        Assert.AreEqual(3, renderer.DefinitionCount);
+    }
+
+    [TestMethod]
+    public void TestAFileWithASurfaceIsNotALibrary()
+    {
+        ImageRenderer renderer = Parse(
+            "Copper = material { pigment color Red }\n" +
+            "sphere { material Copper }\n");
+
+        Assert.IsFalse(renderer.HoldsOnlyDefinitions,
+            "a surface makes the file more than a library");
+    }
+
+    [TestMethod]
+    public void TestAFileWithACameraOrRenderIsNotALibrary()
+    {
+        Assert.IsFalse(Parse(
+            "Copper = material { pigment color Red }\n" +
+            "camera { location [0, 0, -5]  look at [0, 0, 0] }\n").HoldsOnlyDefinitions);
+
+        Assert.IsFalse(Parse(
+            "Copper = material { pigment color Red }\n" +
+            "render\n").HoldsOnlyDefinitions);
+    }
+
+    [TestMethod]
+    public void TestAnEmptyFileDefinesNothing()
+    {
+        ImageRenderer renderer = Parse("// nothing but a comment\n");
+
+        Assert.IsTrue(renderer.HoldsOnlyDefinitions);
+        Assert.AreEqual(0, renderer.DefinitionCount,
+            "an empty file holds no definitions, so there would be nothing to import");
+    }
+
+    [TestMethod]
+    public void TestALibraryConvertedFromPovRayIsAcceptable()
+    {
+        // The real shape of the thing this feature copies: the converted POV-Ray libraries are
+        // exactly named definitions, so one must read back as a library.
+        string library = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".rayTracer", "Libraries", "golds.igl");
+
+        if (!File.Exists(library))
+            Assert.Inconclusive("the POV-Ray libraries are not installed on this machine");
+
+        ImageRenderer renderer = new LanguageParser(library).Parse();
+
+        Assert.IsTrue(renderer.HoldsOnlyDefinitions);
+        Assert.IsTrue(renderer.DefinitionCount > 0);
+    }
+}

--- a/Tests/TestRenderSelection.cs
+++ b/Tests/TestRenderSelection.cs
@@ -1,0 +1,165 @@
+using RayTracer.Options;
+using RayTracer.Parser;
+using RayTracer.Renderer;
+
+namespace Tests;
+
+/// <summary>
+/// These tests cover choosing which scene and camera to render from the command line, which a
+/// file with more than one of either otherwise selects with a <c>render</c> command.  A command
+/// line name takes precedence over the file's.
+/// </summary>
+[TestClass]
+public class TestRenderSelection
+{
+    private string _directory;
+
+    [TestInitialize]
+    public void CreateWorkingDirectory()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), $"render-selection-{Guid.NewGuid():N}");
+
+        Directory.CreateDirectory(_directory);
+    }
+
+    [TestCleanup]
+    public void RemoveWorkingDirectory()
+    {
+        if (Directory.Exists(_directory))
+            Directory.Delete(_directory, true);
+    }
+
+    /// <summary>
+    /// Renders the given scene text with the given command line scene/camera names, and reports
+    /// the error that stopped it, if any, or <c>null</c> when it rendered.
+    /// </summary>
+    private string ErrorFrom(string sceneText, string sceneName = null, string cameraName = null)
+    {
+        string path = Path.Combine(_directory, "scene.igl");
+
+        File.WriteAllText(path, sceneText);
+
+        StringWriter output = new ();
+        TextWriter was = Console.Out;
+
+        Console.SetOut(output);
+
+        try
+        {
+            ImageRenderer renderer = new LanguageParser(path).Parse();
+
+            if (renderer is null)
+                return output.ToString();
+
+            renderer.Render(new RenderOptions
+            {
+                OutputFileName = Path.Combine(_directory, "out.png"),
+                Width = 8, Height = 8,
+                SceneName = sceneName, CameraName = cameraName
+            });
+
+            return output.ToString().Contains("Error") ? output.ToString() : null;
+        }
+        catch (Exception exception)
+        {
+            return exception.Message;
+        }
+        finally
+        {
+            Console.SetOut(was);
+        }
+    }
+
+    private const string TwoScenes =
+        "context { no gamma }\n" +
+        "scene {\n" +
+        "  named 'day'\n" +
+        "  camera { location [0, 0, -5]  look at [0, 0, 0] }\n" +
+        "  point light { location [-4, 6, -8] }\n" +
+        "  sphere { }\n" +
+        "}\n" +
+        "scene {\n" +
+        "  named 'night'\n" +
+        "  camera { location [0, 0, -5]  look at [0, 0, 0] }\n" +
+        "  point light { location [-4, 6, -8] }\n" +
+        "  sphere { }\n" +
+        "}\n";
+
+    private const string TwoCameras =
+        "context { no gamma }\n" +
+        "camera { named 'wide'   location [0, 0, -5]  look at [0, 0, 0]  field of view 70 }\n" +
+        "camera { named 'close'  location [0, 0, -3]  look at [0, 0, 0]  field of view 40 }\n" +
+        "point light { location [-4, 6, -8] }\n" +
+        "sphere { }\n";
+
+    [TestMethod]
+    public void TestTheSceneToRenderMayBeNamedOnTheCommandLine()
+    {
+        // With two scenes and no render command, the file cannot say which to draw...
+        Assert.IsNotNull(ErrorFrom(TwoScenes), "two scenes with no choice made should refuse to render");
+
+        // ... but the command line can.
+        Assert.IsNull(ErrorFrom(TwoScenes, sceneName: "night"));
+    }
+
+    [TestMethod]
+    public void TestTheCameraToRenderMayBeNamedOnTheCommandLine()
+    {
+        Assert.IsNotNull(ErrorFrom(TwoCameras), "two cameras with no choice made should refuse to render");
+
+        Assert.IsNull(ErrorFrom(TwoCameras, cameraName: "wide"));
+    }
+
+    [TestMethod]
+    public void TestAnUnknownCommandLineNameIsReported()
+    {
+        Assert.IsTrue(ErrorFrom(TwoScenes, sceneName: "dusk")!.Contains("dusk"),
+            "naming a scene that does not exist should say so");
+        Assert.IsTrue(ErrorFrom(TwoCameras, cameraName: "telephoto")!.Contains("telephoto"),
+            "naming a camera that does not exist should say so");
+    }
+
+    [TestMethod]
+    public void TestTheCommandLineSceneOverridesTheRenderCommand()
+    {
+        // 'a' has a camera and 'b' does not; the render command chooses 'a', so with no override
+        // the file renders.  Naming 'b' on the command line must win -- and 'b', having no camera,
+        // then fails at the camera, which is how we know the override took effect.
+        string text =
+            "context { no gamma }\n" +
+            "scene {\n" +
+            "  named 'a'\n" +
+            "  camera { location [0, 0, -5]  look at [0, 0, 0] }\n" +
+            "  point light { location [-4, 6, -8] }\n" +
+            "  sphere { }\n" +
+            "}\n" +
+            "scene {\n" +
+            "  named 'b'\n" +
+            "  point light { location [-4, 6, -8] }\n" +
+            "  sphere { }\n" +
+            "}\n" +
+            "render scene 'a'\n";
+
+        Assert.IsNull(ErrorFrom(text), "the render command alone should draw scene 'a'");
+
+        string overridden = ErrorFrom(text, sceneName: "b");
+
+        Assert.IsNotNull(overridden, "overriding to scene 'b' should have taken effect");
+        Assert.IsTrue(overridden.Contains("camera", StringComparison.OrdinalIgnoreCase),
+            "scene 'b' has no camera, so the override should fail there");
+    }
+
+    [TestMethod]
+    public void TestTheCommandLineCameraOverridesTheRenderCommand()
+    {
+        string text =
+            TwoCameras + "render with camera 'wide'\n";
+
+        Assert.IsNull(ErrorFrom(text), "the render command alone should draw with camera 'wide'");
+
+        // The render command names 'wide'; overriding to a name that does not exist must win, and
+        // so must be reported against that name.
+        Assert.IsTrue(ErrorFrom(text, cameraName: "telephoto")!.Contains("telephoto"),
+            "the command line camera name should override the render command's");
+    }
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,6 +118,19 @@ to say you want gamma support.
 or the other and not both.  If you don't specify `--output-dir`, it will default to the
 directory where the input file sits.
 
+#### Which scene, and which camera
+
+| Option | What it does |
+| --- | --- |
+| `--scene` | The scene to render, when the file defines more than one. |
+| `--camera` | The camera to render with, when the scene defines more than one. |
+
+A file that defines several scenes or cameras normally ends with a [`render`
+command](scene-files.md#the-render-command) saying which to use.  These two options say the same
+thing from the command line, and take precedence over the file — so one file can be rendered
+from any of its cameras, or as any of its scenes, without editing it.  A camera name is looked
+for within the chosen scene, so two scenes may each have a camera of the same name.
+
 #### How big, and how good
 
 | Option | Default | What it does |

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -85,18 +85,38 @@ The first column is the name a scene imports by, the second is how much the libr
 the third is where a converted library came from — a library of your own has nothing there to
 say.
 
+### Adding a Library of Your Own
+
+A library of your own — a file like `mine.igl` above — can be installed for every scene to
+share, rather than kept beside one scene, by importing it:
+
+```bash
+RayTracer libraries --import mine.igl
+```
+
+This copies the file into the library directory under its own name, so `mine.igl` becomes the
+library `mine`.  Before it copies anything it reads the file through, so a file that will not
+parse is turned away here rather than the first time a scene reaches for it.
+
+A library may hold **only definitions** — `Name = …` assignments.  A file that also carries a
+surface, a camera, a light or a `render` command is refused, since an import is meant to bring
+across named definitions and nothing else; anything else would be dragged into every scene that
+imported it.  Use `--dry-run` to check a file and see what it would bring without writing
+anything, and `--overwrite` to replace a library of the same name that is already there.
+
 ### Bringing POV-Ray's Textures Across
 
 POV-Ray ships a large collection of finishes, metals, glasses, stones and woods in its
-`include` directory, and the `libraries` verb can convert them:
+`include` directory, and `--import` can convert them all at once when you add `--povray`:
 
 ```bash
-RayTracer libraries --import-povray /path/to/povray/include
+RayTracer libraries --import /path/to/povray/include --povray
 ```
 
-Point it at the `include` directory of a POV-Ray distribution — the one holding `glass.inc`,
-`metals.inc` and the rest.  From a stock distribution it writes ten libraries holding a little
-over six hundred definitions, and reports what each became:
+`--povray` says the thing being imported is a whole POV-Ray distribution to convert rather than
+one `.igl` file to copy, so `--import` is pointed at the `include` directory of a distribution —
+the one holding `glass.inc`, `metals.inc` and the rest.  From a stock distribution it writes ten
+libraries holding a little over six hundred definitions, and reports what each became:
 
 ```
   Library    Materials  Pigments  Interiors  Values
@@ -164,14 +184,14 @@ it gets whichever was read last.
 before any of it lands on disk:
 
 ```bash
-RayTracer libraries --import-povray /path/to/povray/include --dry-run
+RayTracer libraries --import /path/to/povray/include --povray --dry-run
 ```
 
 Importing will not quietly replace libraries already there; pass `--overwrite` when replacing
 them is what you mean:
 
 ```bash
-RayTracer libraries --import-povray /path/to/povray/include --overwrite
+RayTracer libraries --import /path/to/povray/include --povray --overwrite
 ```
 
 One thing to know: a fresh import does not remove libraries it no longer produces.  If a later
@@ -212,9 +232,10 @@ that still imports from it will fail to find it the next time it is rendered.
 
 ### A note on the command names
 
-Every one of these has a short form as well — `-l`, `-p`, `-r`, `-o`, `-d`, `-n` — so a
-first import is often written:
+Every one of these has a short form as well — `-i` for `--import`, `-p` for `--povray`, and
+`-l`, `-r`, `-o`, `-d`, `-n` for the rest — so converting a POV-Ray distribution is often
+written:
 
 ```bash
-RayTracer libraries -p /path/to/povray/include
+RayTracer libraries -i /path/to/povray/include -p
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -729,6 +729,8 @@ other two, `fonts` and `libraries`, have chapters of their own: [Managing Fonts]
 | `-o`, `--output-file` | Name the output image file. |
 | `-d`, `--output-dir` | The directory to write the output in. |
 | `-e`, `--output-extension` | Choose the output format by giving its extension. |
+| `--scene` | The [scene](scene-files.md#scenes-and-cameras) to render, when the file has more than one. |
+| `--camera` | The [camera](cameras.md#placing-a-camera) to render with, when the scene has more than one. |
 | `-w`, `--width` | Image width; otherwise the scene's, otherwise 800. |
 | `-h`, `--height` | Image height; otherwise the scene's, otherwise 600. |
 | `-a`, `--antialias` | The [anti-aliasing](context.md#anti-aliasing) to apply. |
@@ -761,7 +763,8 @@ other two, `fonts` and `libraries`, have chapters of their own: [Managing Fonts]
 | Option | What it does |
 | --- | --- |
 | `-l`, `--list` | List the libraries the ray tracer knows about. |
-| `-p`, `--import-povray` | Convert POV-Ray's include files into libraries. |
+| `-i`, `--import` | Import a library: an `.igl` file of definitions, or (with `--povray`) a POV-Ray include directory. |
+| `-p`, `--povray` | With `--import`, convert a POV-Ray distribution's include files rather than copy one `.igl`. |
 | `-r`, `--remove` | Remove a library. |
 | `-o`, `--overwrite` | Allow an import to replace libraries already there. |
 | `-d`, `--details` | List every definition that could not be converted. |

--- a/docs/scene-files.md
+++ b/docs/scene-files.md
@@ -118,6 +118,12 @@ A file needs a `render` command only when there is a genuine choice to make.  Wi
 scene and a single camera — which is most files — you may leave it off, and that is why none
 of the examples so far have needed one.
 
+The choice can also be made from the command line, with `--scene` and `--camera`, which take
+precedence over anything the file says.  That lets one file be rendered from any of its cameras,
+or as any of its scenes, without editing it — and lets a file with several of either be
+rendered without a `render` command at all.  See
+[Command Line Options](getting-started.md#command-line-options).
+
 ### Background
 
 A ray that strikes nothing still has to come back with *some* color.  By default that color is

--- a/gallery/POVRay/library-textures.igl
+++ b/gallery/POVRay/library-textures.igl
@@ -3,7 +3,7 @@
 // The libraries this leans on are made by the "libraries" command, which reads POV-Ray's own
 // include files and writes the converted libraries into ~/.rayTracer/Libraries:
 //
-//     dotnet run -- libraries --import-povray <povray>/distribution/include
+//     dotnet run -- libraries --import <povray>/distribution/include --povray
 //
 // POV-Ray marks what a thing is with a prefix and we say it in a word at the end, so its
 // T_Gold_3C is imported here as Gold3CMaterial.  Each generated library carries POV-Ray's own


### PR DESCRIPTION
Two command-line changes.

## `--scene` / `--camera`

A file that defines more than one scene or camera normally ends with a `render` command saying which to draw. These two options say the same thing from the command line, and take precedence over the file — so one file can be rendered from any of its cameras, or as any of its scenes, without editing it, and a file with several of either needs no `render` command at all.

The names flow through `RenderContext.ApplyOptions` into `RenderInstruction`, whose `IsolateObject` now prefers a command-line name over the one the `render` command gives, then the file's single default. A camera name is resolved within the chosen scene, so two scenes may reuse a camera name. An unknown name gives the existing clear "No scene/camera named '…' found" error.

## `libraries --import` / `--povray`

`--import-povray <dir>` becomes a more general `--import <path>` plus an optional `--povray`:

- **with `--povray`** — the source is a POV-Ray distribution's `include` directory to convert (the previous behavior);
- **without it** — `--import` copies a single `.igl` file into the library directory, after verifying it holds **only definitions**. A file that also carries a surface, a camera, a light or a `render` command is refused, since an import is meant to bring across named definitions and nothing else — anything else would be dragged into every scene that imported it.

`--dry-run` and `--overwrite` apply to both.

> **CLI change to note:** `--import-povray` is gone. `-i` now means `--import` (it was unused on this verb) and `-p` now means `--povray` (it was `--import-povray`). A script using `--import-povray <dir>` becomes `--import <dir> --povray`.

## Tests

- `TestRenderSelection` — selecting a scene/camera by name, and that the command line overrides the `render` command (proven by overriding to a scene whose missing camera then errors).
- `TestLibraryImport` — a definitions-only file is acceptable; a surface, camera or `render` command is not; an empty file defines nothing; a real converted POV-Ray library reads back clean.

Full suite: 647 passing. Documentation (Getting Started, Scene Files, Using Libraries, Reference) updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)